### PR TITLE
Refactored imports and Vue.use() based on prompt responses. Added transform-imports to Babel config.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,47 @@
 module.exports = (api, options) => {
   const
     theme = options.pluginOptions.quasar.theme,
-    rtl = options.pluginOptions.quasar.rtlSupport
+    rtl = options.pluginOptions.quasar.rtlSupport,
+    all = options.pluginOptions.quasar.framework === 'all'
 
   if (rtl) {
     process.env.QUASAR_RTL = true
   }
 
   api.chainWebpack(chain => {
+    chain.module.rule('babel')
+      .test(/\.jsx?$/)
+      .exclude
+        .add(filepath => {
+          // always transpile js(x) in Vue files
+          if (/\.vue\.jsx?$/.test(filepath)) {
+            return false
+          }
+
+          if ([/[\\/]node_modules[\\/]quasar-framework[\\/]/].some(dep => filepath.match(dep))) {
+            return false
+          }
+
+          // don't transpile anything else in node_modules
+          return /[\\/]node_modules[\\/]/.test(filepath)
+        })
+        .end()
+      .use('babel-loader')
+      .loader('babel-loader')
+        .options({
+          extends: api.resolve('babel.config.js'),
+          plugins: !all ? [
+            [
+              'transform-imports', {
+                quasar: {
+                  transform: `quasar-framework/dist/babel-transforms/imports.${theme}.js`,
+                  preventFullImport: true
+                }
+              }
+            ]
+          ] : []
+        })
+
     chain
       .resolve
         .alias


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x ] Refactor
- [ x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x ] It's submitted to the `dev` branch and _not_ the `master` branch
- [x ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x ] It's been tested with all Quasar themes
- [x ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
