### PR TITLE
fix(generator): unnecessary escape character in vue.config.js, fixes #20

### DIFF
--- a/generator/index.js
+++ b/generator/index.js
@@ -211,6 +211,17 @@ module.exports = (api, opts) => {
       fs.writeFileSync(quasarPath, lines, { encoding: 'utf8' })
     }
 
+    // Remove unnecessary escape characters (https://github.com/quasarframework/vue-cli-plugin-quasar/issues/20)
+    const vueConfigPath = api.resolve('vue.config.js')
+    if (fs.existsSync(vueConfigPath)) {
+      let vueConfig = fs.readFileSync(api.resolve('vue.config.js'), 'utf8')
+      vueConfig = vueConfig.replace(
+        '/[\\\\\\/]node_modules[\\\\\\/]quasar[\\\\\\/]/',
+        '/[\\\\/]node_modules[\\\\/]quasar[\\\\/]/'
+      )
+      fs.writeFileSync(vueConfigPath, vueConfig)
+    }
+
     if (api.generator.hasPlugin('@vue/cli-plugin-eslint')) {
       const { spawnSync } = require('child_process')
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

The text replace is necessary since the escape character is added automatically somewhere, the [generator doesn't have it](https://github.com/quasarframework/vue-cli-plugin-quasar/blob/dev/generator/index.js#L85).