### PR TITLE
fix(auto-import): invalidate component options cache, fix: #30

### DIFF
--- a/lib/loader.auto-import.js
+++ b/lib/loader.auto-import.js
@@ -72,10 +72,10 @@ module.exports = function (content) {
 
       const code = `\nimport {${comp}${hasComp === true && hasDir === true ? ',' : ''}${dir}} from 'quasar'\n` +
         (hasComp === true
-          ? `component.options.components = Object.assign(component.options.components || {}, {${comp}})\n`
+          ? `component.options.components = Object.assign(Object.create(component.options.components || null), component.options.components || {}, {${comp}})\n`
           : '') +
         (hasDir === true
-          ? `component.options.directives = Object.assign(component.options.directives || {}, {${dir}})\n`
+          ? `component.options.directives = Object.assign(Object.create(component.options.directives || null), component.options.directives || {}, {${dir}})\n`
           : '')
 
       return index === -1


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Closes #30.
Related explanation can be found into the issue.