### PR TITLE
Fix/tree shaking

### DIFF
--- a/lib/loader.auto-import.js
+++ b/lib/loader.auto-import.js
@@ -1,7 +1,7 @@
-function getDevlandFile(name) {
+function getDevlandFile (name) {
   return require(
     require.resolve(name, {
-      paths: [__dirname]
+      paths: [ __dirname ]
     })
   )
 }
@@ -22,7 +22,7 @@ const funcCompRegex = new RegExp(
 
 const dirRegex = new RegExp(data.regex.directives, 'g')
 
-function extract(content, form) {
+function extract (content, form) {
   let comp = content.match(compRegex[form]) || []
   let dir = content.match(dirRegex) || []
 
@@ -53,7 +53,7 @@ function extract(content, form) {
   }
 }
 
-module.exports = function(content) {
+module.exports = function (content) {
   if (!this.resourceQuery && funcCompRegex.test(content) === false) {
     const file = this.fs.readFileSync(this.resource, 'utf-8').toString()
     const { comp, dir } = extract(file, this.query)

--- a/lib/loader.auto-import.js
+++ b/lib/loader.auto-import.js
@@ -1,12 +1,13 @@
-function getDevlandFile (name) {
+function getDevlandFile(name) {
   return require(
     require.resolve(name, {
-      paths: [ __dirname ]
+      paths: [__dirname]
     })
   )
 }
 
 const data = getDevlandFile('quasar/dist/babel-transforms/auto-import.json')
+const quasarImportMap = require('quasar/dist/babel-transforms/imports');
 
 const compRegex = {
   '?kebab': new RegExp(data.regex.kebabComponents || data.regex.components, 'g'),
@@ -21,11 +22,11 @@ const funcCompRegex = new RegExp(
 
 const dirRegex = new RegExp(data.regex.directives, 'g')
 
-function extract (content, form) {
-  let comp = content.match(compRegex[form])
-  const directives = content.match(dirRegex)
+function extract(content, form) {
+  let comp = content.match(compRegex[form]) || []
+  let dir = content.match(dirRegex) || []
 
-  if (comp !== null) {
+  if (comp.length) {
     // avoid duplicates
     comp = Array.from(new Set(comp))
 
@@ -39,44 +40,41 @@ function extract (content, form) {
       // so avoid duplicates
       comp = Array.from(new Set(comp))
     }
-
-    comp = comp.join(',')
   }
-  else {
-    comp = ''
+
+  if (dir.length) {
+    dir = Array.from(new Set(dir))
+      .map(name => data.importName[name])
   }
 
   return {
     comp,
-
-    dir: directives !== null
-      ? Array.from(new Set(directives))
-        .map(name => data.importName[name])
-        .join(',')
-      : ''
+    dir,
   }
 }
 
-module.exports = function (content) {
+module.exports = function(content) {
   if (!this.resourceQuery && funcCompRegex.test(content) === false) {
     const file = this.fs.readFileSync(this.resource, 'utf-8').toString()
     const { comp, dir } = extract(file, this.query)
 
-    const hasComp = comp !== ''
-    const hasDir = dir !== ''
-
-    if (hasComp === true || hasDir === true) {
+    if (comp.length || dir.length) {
       const index = this.mode === 'development'
         ? content.indexOf('/* hot reload */')
         : -1
 
-      const code = `\nimport {${comp}${hasComp === true && hasDir === true ? ',' : ''}${dir}} from 'quasar'\n` +
-        (hasComp === true
-          ? `component.options.components = Object.assign(Object.create(component.options.components || null), component.options.components || {}, {${comp}})\n`
-          : '') +
-        (hasDir === true
-          ? `component.options.directives = Object.assign(Object.create(component.options.directives || null), component.options.directives || {}, {${dir}})\n`
-          : '')
+
+      let code = '\n';
+      comp.concat(dir).forEach(quasarComponent => {
+        code += `import ${ quasarComponent } from '${ quasarImportMap(quasarComponent) }';\n`
+      });
+
+      if (comp.length) {
+        code += `component.options.components = Object.assign(Object.create(component.options.components || null), component.options.components || {}, {${ comp.join(',') }})\n`;
+      }
+      if (dir.length) {
+        code += `component.options.directives = Object.assign(Object.create(component.options.directives || null), component.options.directives || {}, {${ dir.join(',') }})\n`;
+      }
 
       return index === -1
         ? content + code


### PR DESCRIPTION
Auto-import generates `import QBtn from 'src/components/btn/QBtn'` instead of `import { QBtn } from 'quasar';` and reduces bundle size significant.

Fixes: #33, #34