### PR TITLE
feat(dependencies): replace deprecated node-sass

### DIFF
--- a/generator/index.js
+++ b/generator/index.js
@@ -50,7 +50,7 @@ module.exports = (api, opts) => {
   }
   else if (['sass', 'scss'].includes(opts.quasar.cssPreprocessor)) {
     Object.assign(deps.devDependencies, {
-      'node-sass': '^4.13.0',
+      'sass': '^1.29.0',
       'sass-loader': '^8.0.0'
     })
   }


### PR DESCRIPTION
- [x] Feature

**Does this PR introduce a breaking change?** (check one)

- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch

**Other information:**
node-sass is officially deprecated.

More details in this article: https://sass-lang.com/blog/libsass-is-deprecated

Vue CLI already dropped the support for node-sass https://github.com/vuejs/vue-cli/pull/6090
