### PR TITLE
fix: Deprecation of loader options in webpack 5 (DEP_WEBPACK_RULE_LOADER_OPTIONS_STRING)

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ module.exports = (api, options) => {
       chain.module.rule('vue')
         .use('vue-auto-import-quasar')
         .loader(path.join(__dirname, 'lib/loader.vue.auto-import-quasar.js'))
-        .options(strategy)
+        .options({ strategy })
         .before('cache-loader')
 
       chain.module.rule('js-transform-quasar-imports')

--- a/lib/loader.vue.auto-import-quasar.js
+++ b/lib/loader.vue.auto-import-quasar.js
@@ -6,9 +6,9 @@ const importTransformation = getDevlandFile('quasar/dist/transforms/import-trans
 const runtimePath = require.resolve('./runtime.auto-import.js')
 
 const compRegex = {
-  '?kebab': new RegExp(autoImportData.regex.kebabComponents || autoImportData.regex.components, 'g'),
-  '?pascal': new RegExp(autoImportData.regex.pascalComponents || autoImportData.regex.components, 'g'),
-  '?combined': new RegExp(autoImportData.regex.components, 'g')
+  'kebab': new RegExp(autoImportData.regex.kebabComponents || autoImportData.regex.components, 'g'),
+  'pascal': new RegExp(autoImportData.regex.pascalComponents || autoImportData.regex.components, 'g'),
+  'combined': new RegExp(autoImportData.regex.components, 'g')
 }
 
 const dirRegex = new RegExp(autoImportData.regex.directives, 'g')
@@ -20,7 +20,10 @@ function transform (itemArray) {
 }
 
 function extract (content, ctx) {
-  let comp = content.match(compRegex[ctx.query])
+  // Use webpack v5 getOptions or fallback to ctx.query for webpack v4
+  const { strategy } = ctx.getOptions ? ctx.getOptions() : ctx.query
+
+  let comp = content.match(compRegex[strategy])
   let dir = content.match(dirRegex)
 
   if (comp === null && dir === null) {
@@ -35,11 +38,11 @@ function extract (content, ctx) {
     comp = Array.from(new Set(comp))
 
     // map comp names only if not pascal-case already
-    if (ctx.query !== '?pascal') {
+    if (strategy !== 'pascal') {
       comp = comp.map(name => autoImportData.importName[name])
     }
 
-    if (ctx.query === '?combined') {
+    if (strategy === 'combined') {
       // could have been transformed QIcon and q-icon too,
       // so avoid duplicates
       comp = Array.from(new Set(comp))


### PR DESCRIPTION
This PR fixes a deprecation warning, when using @vue/cli 5 with webpack 5.
```
[DEP_WEBPACK_RULE_LOADER_OPTIONS_STRING] DeprecationWarning: Using a string as loader options is deprecated (ruleSet[0].use[0].options)
```

Tested with:
* @vue/cli 4 with webpack 4
* @vue/cli 5 with webpack 5

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
