### PR TITLE
Duplicate loader rule matching in webpack config

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,17 +59,18 @@ module.exports = (api, options) => {
     chain.module.rule('vue').use('vue-loader').tap(options => ({
       ...options,
       transformAssetUrls: merge(
-        {
-          base: null,
-          includeAbsolute: false,
-          tags: {
-            video: ['src', 'poster'],
-            source: ['src'],
-            img: ['src'],
-            image: ['xlink:href', 'href'],
-            use: ['xlink:href', 'href']
-          }
-        },
+        // These basic url types are already included in the imported "trasnformAssetUrls"
+        //{
+        //  base: null,
+        //  includeAbsolute: false,
+        //  tags: {
+        //    video: ['src', 'poster'],
+        //    source: ['src'],
+        //    img: ['src'],
+        //    image: ['xlink:href', 'href'],
+        //    use: ['xlink:href', 'href']
+        //  }
+        //},
         options.transformAssetUrls || {},
         transformAssetUrls
       )


### PR DESCRIPTION
Probably not an issue, but the inspecting the webpack config you can see the duplication of tags:
```
      {
        loader: 'vue-loader',
        options: {
          compilerOptions: {},
          transformAssetUrls: {
            base: null,
            includeAbsolute: false,
            tags: {
              video: [
                'src',
                'poster',
                'src',
                'poster',
                [length]: 4
              ],
              source: [
                'src',
                'src',
                [length]: 2
              ],
              img: [
                'src',
                'src',
                [length]: 2
              ],
...
```

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [X] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
